### PR TITLE
Index path helper updates.

### DIFF
--- a/Pod/Classes/URBNArrayDataSourceAdapter.h
+++ b/Pod/Classes/URBNArrayDataSourceAdapter.h
@@ -92,4 +92,14 @@
  */
 - (void)removeAllItems;
 
+/**
+ *  Returns an array of index paths with item set to values in the range param and section set to section param.
+ */
+- (NSArray *)indexPathArrayWithRange:(NSRange)range inSection:(NSInteger)section;
+
+/**
+ *  Returns an array of index paths with item set to the indexes in the indexes param and section set to section param.
+ */
+- (NSArray *)indexPathArrayWithIndexSet:(NSIndexSet *)indexes inSection:(NSInteger)section;
+
 @end

--- a/Pod/Classes/URBNArrayDataSourceAdapter.m
+++ b/Pod/Classes/URBNArrayDataSourceAdapter.m
@@ -21,6 +21,16 @@
     return self;
 }
 
+#pragma mark - Index Path Helpers
+- (NSArray *)indexPathArrayWithRange:(NSRange)range inSection:(NSInteger)section {
+    return [[self class] indexPathArrayWithRange:range inSection:section];
+}
+
+- (NSArray *)indexPathArrayWithIndexSet:(NSIndexSet *)indexes inSection:(NSInteger)section {
+    return [[self class] indexPathArrayWithIndexSet:indexes inSection:section];
+}
+
+
 #pragma mark - updating items
 - (void)removeAllItems {
     [self.items removeAllObjects];
@@ -52,13 +62,15 @@
     
     if (self.tableView) {
         UpdateData();
-        [self.tableView insertRowsAtIndexPaths:[[self class] indexPathArrayWithRange:NSMakeRange(count, [newItems count]) inSection:section] withRowAnimation:self.rowAnimation];
+        [self.tableView insertRowsAtIndexPaths:[self indexPathArrayWithRange:NSMakeRange(count, [newItems count]) inSection:section] withRowAnimation:self.rowAnimation];
     }
     
     if (self.collectionView) {
+        
         [self.collectionView performBatchUpdates:^{
             UpdateData();
-            [self.collectionView insertItemsAtIndexPaths:[[self class] indexPathArrayWithRange:NSMakeRange(count, [newItems count]) inSection:section]];
+            NSArray *paths = [self indexPathArrayWithRange:NSMakeRange(count, [newItems count]) inSection:section];
+            [self.collectionView insertItemsAtIndexPaths:paths];
         } completion:nil];
     }
 }
@@ -78,13 +90,13 @@
 
     if (self.tableView) {
         UpdateData();
-        [self.tableView insertRowsAtIndexPaths:[[self class] indexPathArrayWithIndexSet:indexes inSection:section] withRowAnimation:self.rowAnimation];
+        [self.tableView insertRowsAtIndexPaths:[self indexPathArrayWithIndexSet:indexes inSection:section] withRowAnimation:self.rowAnimation];
     }
     
     if (self.collectionView) {
         [self.collectionView performBatchUpdates:^{
             UpdateData();
-            [self.collectionView insertItemsAtIndexPaths:[[self class] indexPathArrayWithIndexSet:indexes inSection:section]];
+            [self.collectionView insertItemsAtIndexPaths:[self indexPathArrayWithIndexSet:indexes inSection:section]];
         } completion:nil];
     }
 }
@@ -174,12 +186,12 @@
     
     if (self.tableView) {
         UpdateData();
-        [self.tableView deleteRowsAtIndexPaths:[[self class] indexPathArrayWithRange:range inSection:section] withRowAnimation:self.rowAnimation];
+        [self.tableView deleteRowsAtIndexPaths:[self indexPathArrayWithRange:range inSection:section] withRowAnimation:self.rowAnimation];
     }
     
     if (self.collectionView) {
         [self.collectionView performBatchUpdates:^{
-            [self.collectionView deleteItemsAtIndexPaths:[[self class] indexPathArrayWithRange:range inSection:section]];
+            [self.collectionView deleteItemsAtIndexPaths:[self indexPathArrayWithRange:range inSection:section]];
         } completion:nil];
     }
 }
@@ -199,13 +211,13 @@
     
     if (self.tableView) {
         UpdateData();
-        [self.tableView deleteRowsAtIndexPaths:[[self class] indexPathArrayWithIndexSet:indexes inSection:section] withRowAnimation:self.rowAnimation];
+        [self.tableView deleteRowsAtIndexPaths:[self indexPathArrayWithIndexSet:indexes inSection:section] withRowAnimation:self.rowAnimation];
     }
     
     if (self.collectionView) {
         [self.collectionView performBatchUpdates:^{
             UpdateData();
-            [self.collectionView deleteItemsAtIndexPaths:[[self class] indexPathArrayWithIndexSet:indexes inSection:section]];
+            [self.collectionView deleteItemsAtIndexPaths:[self indexPathArrayWithIndexSet:indexes inSection:section]];
         } completion:nil];
     }
 }

--- a/Pod/Classes/URBNDataSourceAdapter.m
+++ b/Pod/Classes/URBNDataSourceAdapter.m
@@ -201,7 +201,7 @@ NSString *const URBNSupplementaryViewKindFooter = @"URBNSupplementaryViewKindFoo
 + (NSArray *)indexPathArrayWithRange:(NSRange)range inSection:(NSInteger)section {
     NSMutableArray *ret = [NSMutableArray array];
     for( NSInteger i = range.location; i < NSMaxRange(range); i++) {
-        [ret addObject:[NSIndexPath indexPathForRow:(NSInteger)i inSection:0]];
+        [ret addObject:[NSIndexPath indexPathForRow:(NSInteger)i inSection:section]];
     }
     
     return ret;

--- a/URBNDataSource.podspec
+++ b/URBNDataSource.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'URBNDataSource'
-  s.version          = '0.5'
+  s.version          = '0.5.1'
   s.summary          = 'URBNDataSource is meant to be a convenience wrapper around UICollectionView / UITableView data management'
   s.homepage         = 'https://github.com/urbn/URBNDataSource'
   s.license          = 'MIT'


### PR DESCRIPTION
Implements index path helper methods as instance methods on URBNArrayDataSourceAdapter so subclasses can override if needed.
Fixes an issue in class method +indexPathArrayWithRange:inSection: to return an index path with the specified section instead of always 0.