### PR TITLE
Section Management

### DIFF
--- a/Example/URBNDataSource/MainStoryboard.storyboard
+++ b/Example/URBNDataSource/MainStoryboard.storyboard
@@ -317,7 +317,20 @@
                             <outlet property="delegate" destination="2ll-N1-rdu" id="vPD-ng-kuV"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Accordion Table View" id="KYA-kr-puI"/>
+                    <navigationItem key="navigationItem" title="Accordion Table View" id="KYA-kr-puI">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="6o9-m3-Yl5">
+                            <stepper key="customView" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" id="FaS-6H-S64">
+                                <rect key="frame" x="-47" y="-14" width="94" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="stepperPressed:" destination="2ll-N1-rdu" eventType="valueChanged" id="ouM-3l-Akd"/>
+                                </connections>
+                            </stepper>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="stepper" destination="FaS-6H-S64" id="X9w-fw-Elq"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="r7o-g3-43Y" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -343,7 +356,20 @@
                             <outlet property="delegate" destination="0dd-5H-FHB" id="Ypx-De-BiS"/>
                         </connections>
                     </collectionView>
-                    <navigationItem key="navigationItem" title="Accordion Collection View" id="5q1-c1-cTq"/>
+                    <navigationItem key="navigationItem" title="Accordion Collection View" id="5q1-c1-cTq">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="kCz-X8-AWg">
+                            <stepper key="customView" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" maximumValue="20" id="dRq-04-wza">
+                                <rect key="frame" x="-47" y="-14" width="94" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="stepperPressed:" destination="0dd-5H-FHB" eventType="valueChanged" id="leJ-c6-8ec"/>
+                                </connections>
+                            </stepper>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="stepper" destination="dRq-04-wza" id="Tdb-xR-mD3"/>
+                    </connections>
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8xy-qR-AoU" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Example/URBNDataSource/ViewControllers/Code Accordion CollectionView/URBNAccordionCollectionVC.m
+++ b/Example/URBNDataSource/ViewControllers/Code Accordion CollectionView/URBNAccordionCollectionVC.m
@@ -140,8 +140,9 @@
 }
 
 - (IBAction)stepperPressed:(UIStepper *)stepper {
-    if (stepper.value > self.adapter.sections.count) {
-        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)self.adapter.sections.count] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
+    NSUInteger sectionCount = [self.adapter allSections].count;
+    if (stepper.value > sectionCount) {
+        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)sectionCount] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
     }
     else {
         [self.adapter removeLastSection];

--- a/Example/URBNDataSource/ViewControllers/Code Accordion CollectionView/URBNAccordionCollectionVC.m
+++ b/Example/URBNDataSource/ViewControllers/Code Accordion CollectionView/URBNAccordionCollectionVC.m
@@ -80,6 +80,7 @@
 
 @interface URBNAccordionCollectionVC ()
 @property (nonatomic, strong) URBNAccordionDataSourceAdapter *adapter;
+@property (weak, nonatomic) IBOutlet UIStepper *stepper;
 @end
 
 @implementation URBNAccordionCollectionVC
@@ -91,10 +92,11 @@
     
     NSMutableArray *items = [NSMutableArray array];
     NSMutableArray *sections = [NSMutableArray array];
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 4; i++) {
         [sections addObject:[NSString stringWithFormat:@"Section %i", i]];
         [items addObject:@[@"Item 0", @"Item 1", @"Item 2", @"Item 3", @"Item 4"]];
     }
+    self.stepper.value = (double)sections.count;
     
     self.adapter = [[URBNAccordionDataSourceAdapter alloc] initWithSectionObjects:sections andItems:items];
     self.adapter.fallbackDataSource = self;
@@ -135,6 +137,15 @@
     }];
     
     self.collectionView.dataSource = self.adapter;
+}
+
+- (IBAction)stepperPressed:(UIStepper *)stepper {
+    if (stepper.value > self.adapter.sections.count) {
+        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)self.adapter.sections.count] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
+    }
+    else {
+        [self.adapter removeLastSection];
+    }
 }
 
 @end

--- a/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
+++ b/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
@@ -126,8 +126,9 @@
 }
 
 - (IBAction)stepperPressed:(UIStepper *)stepper {
-    if (stepper.value > self.adapter.sections.count) {
-        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)self.adapter.sections.count] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
+    NSUInteger sectionCount = [self.adapter allSections].count;
+    if (stepper.value > sectionCount) {
+        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)sectionCount] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
     }
     else {
         [self.adapter removeLastSection];

--- a/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
+++ b/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
@@ -81,6 +81,7 @@
 @interface URBNAccordionTableViewController ()
 
 @property (nonatomic, strong) URBNAccordionDataSourceAdapter *adapter;
+@property (weak, nonatomic) IBOutlet UIStepper *stepper;
 
 @end
 
@@ -91,10 +92,11 @@
     
     NSMutableArray *items = [NSMutableArray array];
     NSMutableArray *sections = [NSMutableArray array];
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 5; i++) {
         [sections addObject:[NSString stringWithFormat:@"Section %i", i]];
         [items addObject:@[@"Item 0", @"Item 1", @"Item 2", @"Item 3", @"Item 4"]];
     }
+    self.stepper.value = (double)sections.count;
 
     self.adapter = [[URBNAccordionDataSourceAdapter alloc] initWithSectionObjects:sections andItems:items];
     self.adapter.fallbackDataSource = self;
@@ -121,6 +123,15 @@
     
     self.tableView.delegate = self.adapter;
     self.tableView.dataSource = self.adapter;
+}
+
+- (IBAction)stepperPressed:(UIStepper *)stepper {
+    if (stepper.value > self.adapter.sections.count) {
+        [self.adapter appendSectionObject:[NSString stringWithFormat:@"Section %lu", (unsigned long)self.adapter.sections.count] items:@[@"Item A", @"Item B", @"Item C", @"Item D", @"Item E"]];
+    }
+    else {
+        [self.adapter removeLastSection];
+    }
 }
 
 @end

--- a/Pod/Classes/URBNAccordionDataSourceAdapter.h
+++ b/Pod/Classes/URBNAccordionDataSourceAdapter.h
@@ -12,6 +12,7 @@ typedef void (^URBNAccordionHeaderViewConfigureBlock) (id view, id object, NSInt
 
 @interface URBNAccordionDataSourceAdapter : URBNArrayDataSourceAdapter
 
+@property (nonatomic, strong, readonly) NSArray *sections;
 @property (nonatomic, assign) BOOL allowMultipleExpandedSections;
 @property (nonatomic, strong) NSIndexSet *sectionsToKeepOpen;
 
@@ -58,5 +59,13 @@ typedef void (^URBNAccordionHeaderViewConfigureBlock) (id view, id object, NSInt
  *  @return BOOL        YES/NO depending on the current status of the given section.
  */
 - (BOOL)sectionIsOpen:(NSInteger)section;
+
+/**
+ *  Appends a section to the view.
+ *
+ *  @param sectionObject The section object being added
+ *  @param items         The items being adding to the section
+ */
+- (void)appendSectionObject:(id)sectionObject items:(NSArray *)items;
 
 @end

--- a/Pod/Classes/URBNAccordionDataSourceAdapter.h
+++ b/Pod/Classes/URBNAccordionDataSourceAdapter.h
@@ -12,7 +12,6 @@ typedef void (^URBNAccordionHeaderViewConfigureBlock) (id view, id object, NSInt
 
 @interface URBNAccordionDataSourceAdapter : URBNArrayDataSourceAdapter
 
-@property (nonatomic, strong, readonly) NSArray *sections;
 @property (nonatomic, assign) BOOL allowMultipleExpandedSections;
 @property (nonatomic, strong) NSIndexSet *sectionsToKeepOpen;
 
@@ -67,5 +66,12 @@ typedef void (^URBNAccordionHeaderViewConfigureBlock) (id view, id object, NSInt
  *  @param items         The items being adding to the section
  */
 - (void)appendSectionObject:(id)sectionObject items:(NSArray *)items;
+
+/**
+ *  Returns an array of all section
+ *
+ *  @return all sections
+ */
+- (NSArray *)allSections;
 
 @end

--- a/Pod/Classes/URBNAccordionDataSourceAdapter.m
+++ b/Pod/Classes/URBNAccordionDataSourceAdapter.m
@@ -10,7 +10,7 @@
 
 @interface URBNAccordionDataSourceAdapter ()
 
-@property (nonatomic, strong) NSArray *sections;
+@property (nonatomic, strong) NSMutableArray *sections;
 @property (nonatomic, strong) NSMutableArray *items;
 @property (nonatomic, strong) NSMutableIndexSet *expandedSections;
 @property (nonatomic, strong) NSMutableDictionary *headerConfigBlocks;
@@ -28,7 +28,7 @@
     if (self) {
         NSAssert(sections, @"You need sections for an accordion. Stop being a jerk.");
         NSAssert(sections.count > 0, @"Nice try, an empty sections array isn't gonna cut it. GTFO.");
-        self.sections = [sections copy];
+        self.sections = [NSMutableArray arrayWithArray:sections];
         self.items = [NSMutableArray arrayWithArray:items];
 
         self.expandedSections = [NSMutableIndexSet indexSet];
@@ -118,17 +118,22 @@
 }
 
 - (void)appendSectionWithItems:(NSArray *)newItems {
-    NSAssert(YES, @"Call appendSectionObject:items:expanded: instead");
+    [self appendSectionObject:nil items:newItems];
 }
 
 - (void)appendSectionObject:(id)sectionObject items:(NSArray *)items {
-    self.sections = [self.sections arrayByAddingObject:sectionObject];
-    [super appendSectionWithItems:items];
+    NSAssert(sectionObject, @"A sectionObject must be included when appending a section. Call appendSectionObject:items: instead");
+    [self.sections addObject:sectionObject];
+    [super appendSectionWithItems:[NSArray arrayWithArray:items]];
+}
+
+- (NSArray *)allSections {
+    return [self.sections copy];
 }
 
 - (void)removeLastSection {
     if (self.sections.count > 0) {
-        self.sections = [self.sections subarrayWithRange:NSMakeRange(0, self.sections.count - 1)];
+        [self.sections removeLastObject];
     }
     [super removeLastSection];
 }

--- a/Pod/Classes/URBNAccordionDataSourceAdapter.m
+++ b/Pod/Classes/URBNAccordionDataSourceAdapter.m
@@ -10,7 +10,7 @@
 
 @interface URBNAccordionDataSourceAdapter ()
 
-@property (nonatomic, strong) NSMutableArray *sections;
+@property (nonatomic, strong) NSArray *sections;
 @property (nonatomic, strong) NSMutableArray *items;
 @property (nonatomic, strong) NSMutableIndexSet *expandedSections;
 @property (nonatomic, strong) NSMutableDictionary *headerConfigBlocks;
@@ -28,7 +28,7 @@
     if (self) {
         NSAssert(sections, @"You need sections for an accordion. Stop being a jerk.");
         NSAssert(sections.count > 0, @"Nice try, an empty sections array isn't gonna cut it. GTFO.");
-        self.sections = [NSMutableArray arrayWithArray:sections];
+        self.sections = [sections copy];
         self.items = [NSMutableArray arrayWithArray:items];
 
         self.expandedSections = [NSMutableIndexSet indexSet];
@@ -115,6 +115,22 @@
 
 - (BOOL)sectionIsOpen:(NSInteger)section {
     return [self.sectionsToKeepOpen containsIndex:section] || [self.expandedSections containsIndex:section];
+}
+
+- (void)appendSectionWithItems:(NSArray *)newItems {
+    NSAssert(YES, @"Call appendSectionObject:items:expanded: instead");
+}
+
+- (void)appendSectionObject:(id)sectionObject items:(NSArray *)items {
+    self.sections = [self.sections arrayByAddingObject:sectionObject];
+    [super appendSectionWithItems:items];
+}
+
+- (void)removeLastSection {
+    if (self.sections.count > 0) {
+        self.sections = [self.sections subarrayWithRange:NSMakeRange(0, self.sections.count - 1)];
+    }
+    [super removeLastSection];
 }
 
 #pragma mark - UITableViewDataSource

--- a/Pod/Classes/URBNArrayDataSourceAdapter.h
+++ b/Pod/Classes/URBNArrayDataSourceAdapter.h
@@ -34,6 +34,13 @@
 - (void)appendItems:(NSArray *)newItems inSection:(NSInteger)section;
 
 /**
+ * Appends a new section with the new items. If not sectioned, this does nothing.
+ *
+ *  @param newItems The new items
+ */
+- (void)appendSectionWithItems:(NSArray *)newItems;
+
+/**
  * Insert some items at the specified indexes.
  * The count of `items` should be equal to the number of `indexes`.
  *
@@ -88,6 +95,11 @@
  *  @param indexPath The indexPath to remove
  */
 - (void)removeItemAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ *  Removes the last section. If isSectioned is false, or there are no items, this does nothing
+ */
+- (void)removeLastSection;
 
 /**
  * Move an item to a new indexPath.

--- a/Pod/Classes/URBNArrayDataSourceAdapter.h
+++ b/Pod/Classes/URBNArrayDataSourceAdapter.h
@@ -34,7 +34,7 @@
 - (void)appendItems:(NSArray *)newItems inSection:(NSInteger)section;
 
 /**
- * Appends a new section with the new items. If not sectioned, this does nothing.
+ * Appends a new section with the new items.
  *
  *  @param newItems The new items
  */

--- a/Pod/Classes/URBNArrayDataSourceAdapter.m
+++ b/Pod/Classes/URBNArrayDataSourceAdapter.m
@@ -93,6 +93,27 @@
     }
 }
 
+- (void)appendSectionWithItems:(NSArray *)newItems {
+    
+    if ([self isSectioned]) {
+        void (^updateData)() = ^{
+            [self.items addObject:newItems];
+        };
+        
+        if (self.tableView) {
+            updateData();
+            [self.tableView insertSections:[NSIndexSet indexSetWithIndex:(self.items.count - 1)] withRowAnimation:UITableViewRowAnimationFade];
+        }
+        
+        if (self.collectionView) {
+            [self.collectionView performBatchUpdates:^{
+                updateData();
+                [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:(self.items.count - 1)]];
+            } completion:nil];
+        }
+    }
+}
+
 - (void)insertItems:(NSArray *)newItems atIndexes:(NSIndexSet *)indexes inSection:(NSInteger)section {
     NSMutableArray *tempItems = [[self itemsForSection:section] mutableCopy];
     [tempItems insertObjects:newItems atIndexes:indexes];
@@ -257,6 +278,21 @@
     
     if (self.collectionView) {
         [self.collectionView deleteItemsAtIndexPaths:@[indexPath]];
+    }
+}
+
+- (void)removeLastSection {
+    if ([self isSectioned] && (self.items.count > 0)) {
+        [self.items removeLastObject];
+
+        NSIndexSet *deletedSection = [NSIndexSet indexSetWithIndex:self.items.count];
+        if (self.tableView) {
+            [self.tableView deleteSections:deletedSection withRowAnimation:UITableViewRowAnimationFade];
+        }
+        
+        if (self.collectionView) {
+            [self.collectionView deleteSections:deletedSection];
+        }
     }
 }
 


### PR DESCRIPTION
Added `appendSectionwithItems:` and `removeLastSection` to `URBNArrayDataSourceAdapter`
Added `appendSectionWithObject:items:` to `URBNAccordionDataSourceAdapter`.

If `isSection` isn’t set, these methods do nothing. I exposed section as a readonly Array (no mutable) because this information can be helpful.