### PR TITLE
Expose the Supplementary View Kind String Constants

### DIFF
--- a/Pod/Classes/URBNDataSourceAdapter.h
+++ b/Pod/Classes/URBNDataSourceAdapter.h
@@ -9,6 +9,9 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+OBJC_EXPORT NSString *const URBNSupplementaryViewKindHeader;
+OBJC_EXPORT NSString *const URBNSupplementaryViewKindFooter;
+
 typedef NS_ENUM(NSUInteger, URBNSupplementaryViewType) {
     URBNSupplementaryViewTypeHeader,
     URBNSupplementaryViewTypeFooter


### PR DESCRIPTION
These are needed because `setSupplementaryViewIdentifierBlock:` uses the `kind` string parameter and I want to be able to compare to the defined constants