### PR TITLE
ios 9 UITableViewHeaderFooterView fix

### DIFF
--- a/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
+++ b/Example/URBNDataSource/ViewControllers/Code Accordion TableView/URBNAccordionTableViewController.m
@@ -22,8 +22,9 @@
 
 @implementation URBNAccordionHeader
 
-- (instancetype)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
+- (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithReuseIdentifier:reuseIdentifier];
+    
     if (self) {
         self.contentView.backgroundColor = [UIColor whiteColor];
         


### PR DESCRIPTION
Found an issue where section headers are not showing with ios9.  UITableViewHeaderFooterView subclass must override initWithReuseIdentifier instead of initWithFrame.