### PR TITLE
for registering class with identifier, use class name for nibname

### DIFF
--- a/Pod/Classes/URBNDataSourceAdapter.m
+++ b/Pod/Classes/URBNDataSourceAdapter.m
@@ -276,7 +276,7 @@ NSString *const URBNSupplementaryViewKindFooter = @"URBNSupplementaryViewKindFoo
     ASSERT_TRUE(self.tableView || self.collectionView);
     
     identifier = identifier?:NSStringFromClass(cellClass);
-    UINib* nib = [self nibWithName:identifier];
+    UINib* nib = [self nibWithName:NSStringFromClass(cellClass)];
     if (nib) {
         [self.tableView registerNib:nib forCellReuseIdentifier:identifier];
         [self.collectionView registerNib:nib forCellWithReuseIdentifier:identifier];


### PR DESCRIPTION
don't use passed in identifier. current setup makes it impossible
to have multiple blocks for classes with nibs. also this matches
the way supplementary view is using identifier + nib